### PR TITLE
Explore: add image link to mybinder-hosted tutorial

### DIFF
--- a/content/pages/explore.html
+++ b/content/pages/explore.html
@@ -16,7 +16,13 @@
      data types and also a few quality metrics used to investigate the utility
      of the dataset. A comprehensive assessment can be found in the associated
      data papers that are available for every dataset component listed on the
-     <a href="/data.html">Data Page</a>.</p>
+     <a href="/data.html">Data Page</a>. An interactive walk-through tutorial
+     is also available to provide hands-on experience with the
+     StudyForrest dataset and DataLad: 
+     <a href="https://mybinder.org/v2/gh/psychoinformatics-de/studyforrest-data-binder/HEAD?filepath=exploring_studyforrest_with_datalad.ipynb">
+      <img border="0" alt="binder" src="https://mybinder.org/badge_logo.svg">
+    </a>
+  </p>
 
   <h2>The "Hairy" Brain</h2>
   <p>Diffusion-weighted imaging (DWI) is a technique that can be used to


### PR DESCRIPTION
Another option is just to hyperlink a word or phrase, and not the binder icon. I like it being visible, and the binder icon is becoming synonymous (IME) with linking to an interactive notebook. But I have no problems changing it.