### PR TITLE
BF: Allow to build non-doi-based URLs for publications that do not have a doi

### DIFF
--- a/content/pages/publications.html
+++ b/content/pages/publications.html
@@ -359,7 +359,7 @@
     </tr>
 
     <tr>
-      <td><a href=https://www.doi.org/https://arxiv.org/abs/1606.02627v1>Brains on Beats</a></td>
+      <td><a href=https://arxiv.org/abs/1606.02627v1>Brains on Beats</a></td>
       <td>Umut Güçlü, Jordy Thielen, Michael Hanke, Marcel van Gerven</td>
       <td>Advances in Neural Information Processing Systems (NIPS)</td>
       <td>2016</td>
@@ -463,7 +463,7 @@
     </tr>
 
     <tr>
-      <td><a href=https://www.doi.org/https://proceedings.neurips.cc/paper/2015/file/b3967a0e938dc2a6340e258630febd5a-Paper.pdf>A Reduced-Dimension fMRI Shared Response Model</a></td>
+      <td><a href=https://proceedings.neurips.cc/paper/2015/file/b3967a0e938dc2a6340e258630febd5a-Paper.pdf>A Reduced-Dimension fMRI Shared Response Model</a></td>
       <td>Po-Hsuan (Cameron) Chen, Janice Chen, Yaara Yeshurun, Uri Hasson, James Haxby, Peter J. Ramadge</td>
       <td>Advances in Neural Information Processing Systems</td>
       <td>2015</td>

--- a/tools/publications.html
+++ b/tools/publications.html
@@ -338,7 +338,7 @@
     </tr>
 
     <tr>
-      <td><a href=https://www.doi.org/https://arxiv.org/abs/1606.02627v1>Brains on Beats</a></td>
+      <td><a href=https://arxiv.org/abs/1606.02627v1>Brains on Beats</a></td>
       <td>Umut Güçlü, Jordy Thielen, Michael Hanke, Marcel van Gerven</td>
       <td>Advances in Neural Information Processing Systems (NIPS)</td>
       <td>2016</td>
@@ -442,7 +442,7 @@
     </tr>
 
     <tr>
-      <td><a href=https://www.doi.org/https://proceedings.neurips.cc/paper/2015/file/b3967a0e938dc2a6340e258630febd5a-Paper.pdf>A Reduced-Dimension fMRI Shared Response Model</a></td>
+      <td><a href=https://proceedings.neurips.cc/paper/2015/file/b3967a0e938dc2a6340e258630febd5a-Paper.pdf>A Reduced-Dimension fMRI Shared Response Model</a></td>
       <td>Po-Hsuan (Cameron) Chen, Janice Chen, Yaara Yeshurun, Uri Hasson, James Haxby, Peter J. Ramadge</td>
       <td>Advances in Neural Information Processing Systems</td>
       <td>2015</td>

--- a/tools/pubs.py
+++ b/tools/pubs.py
@@ -106,10 +106,22 @@ def restructure_to_html(metadata_db):
         title = v['title']
         date = v['pubdate'][:4]
         # construct a doi url
-        url = 'https://www.doi.org/' + \
-              [v['articleids'][i]['value']
-               for i in range(len(v['articleids']))
-               if v['articleids'][i]['idtype'] == 'doi'][0]
+        customurl = False
+        customurl_value = None
+        for i in range(len(v['articleids'])):
+            if v['articleids'][i]['idtype'] == 'doi':
+                if v['articleids'][i]['value'].startswith('http'):
+                    print(f"I did not find a DOI for the paper {title}, but it"
+                          f"seems I got an HTTP or HTTPS URL for them.")
+                    customurl_value = v['articleids'][i]['value']
+                    customurl = True
+        if not customurl:
+            url = 'https://www.doi.org/' + \
+                  [v['articleids'][i]['value']
+                   for i in range(len(v['articleids']))
+                   if v['articleids'][i]['idtype'] == 'doi'][0]
+        else:
+            url = customurl_value
         journal = v['fulljournalname']
         if v['articletype'] == 'TODO':
             # this has not been altered by a human yet. By default,


### PR DESCRIPTION
Not the most elegant, but a fix for #49. Other than code changes, this PR includes a reconversion of the html table, and an update of the raw sources of the publication page.